### PR TITLE
Add a basic REST API for stopping and starting watchers

### DIFF
--- a/autoed/server/__init__.py
+++ b/autoed/server/__init__.py
@@ -4,22 +4,22 @@ import uvicorn
 
 
 def run():
-    parser = argparse.ArgumentParser(description='Start the AutoED server')
+    parser = argparse.ArgumentParser(description="Start the AutoED server")
     parser.add_argument(
-        '--host',
-        help='Listen for incoming connections on a specific interface (IP address or hostname; default: all)',
-        default='0.0.0.0',
+        "--host",
+        help="Listen for incoming connections on a specific interface (IP address or hostname; default: all)",
+        default="0.0.0.0",
     )
     parser.add_argument(
-        '--port',
-        help='Listen for incoming TCP connections on this port (default: 8001)',
+        "--port",
+        help="Listen for incoming TCP connections on this port (default: 8001)",
         type=int,
         default=8000,
     )
     args = parser.parse_args()
 
     config = uvicorn.Config(
-        'autoed.server.main:app',
+        "autoed.server.main:app",
         host=args.host,
         port=args.port,
         log_config=None,

--- a/autoed/server/__init__.py
+++ b/autoed/server/__init__.py
@@ -1,0 +1,31 @@
+import argparse
+
+import uvicorn
+
+
+def run():
+    parser = argparse.ArgumentParser(description='Start the AutoED server')
+    parser.add_argument(
+        '--host',
+        help='Listen for incoming connections on a specific interface (IP address or hostname; default: all)',
+        default='0.0.0.0',
+    )
+    parser.add_argument(
+        '--port',
+        help='Listen for incoming TCP connections on this port (default: 8001)',
+        type=int,
+        default=8000,
+    )
+    args = parser.parse_args()
+
+    config = uvicorn.Config(
+        'autoed.server.main:app',
+        host=args.host,
+        port=args.port,
+        log_config=None,
+        ws_ping_interval=300,
+        ws_ping_timeout=300,
+    )
+
+    _running_server = uvicorn.Server(config=config)
+    _running_server.run()

--- a/autoed/server/api.py
+++ b/autoed/server/api.py
@@ -1,0 +1,55 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from autoed.autoed import AutoedDaemon, kill_process_and_children
+
+router = APIRouter(prefix='/api/v1')
+
+autoed_daemon = AutoedDaemon()
+
+
+class Watcher(BaseModel):
+    path: str
+    pid: int
+
+
+@router.get('/watchers')
+def get_watchers() -> list[Watcher]:
+    return [
+        {'path': d, 'pid': autoed_daemon.pids[d]}
+        for d in autoed_daemon.directories.values()
+    ]
+
+
+class PID(BaseModel):
+    pid: int
+
+
+@router.get('/watchers/{path:path}/pid')
+def get_watcher_pid(path: str) -> PID:
+    return autoed_daemon.pids[path]
+
+
+class WatcherSetup(BaseModel):
+    path: str
+    inotify: bool = False
+    sleep_time: float = 30
+    log_dir: str = ''
+    slurm: bool = False
+
+
+@router.post('/watcher')
+def start_watcher(watcher_setup: WatcherSetup):
+    autoed_daemon.watch(
+        dirname=watcher_setup.path,
+        use_inotify=watcher_setup.inotify,
+        sleep_time=watcher_setup.sleep_time,
+        log_dir=watcher_setup.log_dir,
+        no_slurm=not watcher_setup.slurm,
+    )
+
+
+@router.delete('/watchers/{pid}')
+def stop_watcher(pid: int):
+    if pid in autoed_daemon.pids.values():
+        kill_process_and_children(pid)

--- a/autoed/server/auth.py
+++ b/autoed/server/auth.py
@@ -14,7 +14,12 @@ router = APIRouter(prefix="/api/v1")
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/token")
 
-AUTH_KEY = os.environ.get("AUTOED_AUTH_KEY") or secrets.token_hex(32)
+if os.environ.get("AUTOED_CREDENTIALS"):
+    with open(os.environ["AUTOED_CREDENTIALS"], "r") as fs:
+        creds = yaml.safe_load(fs)
+    AUTH_KEY = creds.get("auth_key") or secrets.token_hex(32)
+else:
+    AUTH_KEY = secrets.token_hex(32)
 
 
 def get_creds() -> dict:

--- a/autoed/server/auth.py
+++ b/autoed/server/auth.py
@@ -1,0 +1,76 @@
+import secrets
+import os
+import yaml
+
+from jose import JWTError, jwt
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm, OAuth2PasswordBearer
+from pydantic import BaseModel
+
+from typing import Annotated
+
+router = APIRouter(prefix="/api/v1")
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/token")
+
+AUTH_KEY = os.environ.get("AUTOED_AUTH_KEY") or secrets.token_hex(32)
+
+
+def get_creds() -> dict:
+    if not os.environ.get("AUTOED_CREDENTIALS"):
+        return {}
+    try:
+        with open(os.environ["AUTOED_CREDENTIALS"], "r") as fs:
+            creds = yaml.safe_load(fs)
+    except Exception:
+        return {}
+    return creds
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str
+
+
+def create_access_token(data: dict):
+    to_encode = data.copy()
+
+    encoded_jwt = jwt.encode(to_encode, AUTH_KEY, algorithm="HS256")
+    return encoded_jwt
+
+
+async def validate_token(token: Annotated[str, Depends(oauth2_scheme)]):
+    try:
+        creds = get_creds()
+        if not creds:
+            raise JWTError
+        decoded_data = jwt.decode(token, AUTH_KEY, algorithms=["HS256"])
+        if decoded_data.get("username"):
+            if not decoded_data["username"] == creds.get("username"):
+                raise JWTError
+        else:
+            raise JWTError
+    except JWTError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return None
+
+
+@router.post("/token")
+async def login(form_data: Annotated[OAuth2PasswordRequestForm, Depends()]) -> Token:
+    creds = get_creds()
+    if not creds:
+        raise HTTPException(status_code=400, detail="Credentials file invalid")
+    if not (
+        form_data.username == creds.get("username")
+        and form_data.password == creds.get("password")
+    ):
+        raise HTTPException(status_code=400, detail="Incorrect username or password")
+    access_token = create_access_token(
+        data={"username": form_data.username},
+    )
+    return Token(access_token=access_token, token_type="bearer")

--- a/autoed/server/main.py
+++ b/autoed/server/main.py
@@ -1,0 +1,20 @@
+import os
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from autoed.server.api import router
+
+app = FastAPI(title='Murfey instrument server', debug=True)
+
+if os.environ.get('AUTOED_SERVER_ALLOWED_CLIENTS'):
+    allow_origins = os.environ['AUTOED_SERVER_ALLOWED_CLIENTS'].split(",")
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=allow_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+app.include_router(router)

--- a/autoed/server/main.py
+++ b/autoed/server/main.py
@@ -4,11 +4,12 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from autoed.server.api import router
+from autoed.server.auth import router as authrouter
 
-app = FastAPI(title='Murfey instrument server', debug=True)
+app = FastAPI(title="Murfey instrument server", debug=True)
 
-if os.environ.get('AUTOED_SERVER_ALLOWED_CLIENTS'):
-    allow_origins = os.environ['AUTOED_SERVER_ALLOWED_CLIENTS'].split(",")
+if os.environ.get("AUTOED_SERVER_ALLOWED_CLIENTS"):
+    allow_origins = os.environ["AUTOED_SERVER_ALLOWED_CLIENTS"].split(",")
     app.add_middleware(
         CORSMiddleware,
         allow_origins=allow_origins,
@@ -18,3 +19,4 @@ if os.environ.get('AUTOED_SERVER_ALLOWED_CLIENTS'):
     )
 
 app.include_router(router)
+app.include_router(authrouter)

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,10 @@ setup(
         'psutil'
     ],
     extras_require={
-        'server': ['fastapi'],
+        'server': [
+            'fastapi[standard]',
+            'pyyaml',
+            'python-jose',
+            ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ setup(
             'autoed_watch = autoed.watch:main',
             'autoed = autoed.autoed:main',
             'autoed_beam_center = autoed.beam_position.beam_center:main',
-            'autoed_process = autoed.process.process_static:main'
+            'autoed_process = autoed.process.process_static:main',
+            'autoed_server = autoed.server:run',
         ]
     },
     setup_requires=['argcomplete'],
@@ -25,5 +26,8 @@ setup(
         'pathlib',
         'argcomplete',
         'psutil'
-    ]
+    ],
+    extras_require={
+        'server': ['fastapi'],
+    },
 )


### PR DESCRIPTION
This will help us run the autoed daemon as a privileged user at DLS and trigger watching based on acquisition.

There is a very basic authentication implementation which reads a username and password from a yaml file pointed to with the `AUTOED_CREDENTIALS` environment variable. These can be used to generate a token for authentication of requests to the API. A key can also be set in here to ensure consistent token encryption through server restarts. The `AUTOED_SERVER_ALLOWED_CLIENTS` can be used to give access only to a comma separated list of hostnames.

To start the server just `autoed_server`. To install from a local copy with the server component dependencies `pip install ".[server]"`