### PR TITLE
Allow configuration file to be specified in API calls and passed on to subprocesses

### DIFF
--- a/autoed/autoed.py
+++ b/autoed/autoed.py
@@ -246,6 +246,7 @@ class AutoedDaemon:
               dummy=False,
               local=False,
               test=False,
+              config_file: str | None = None,
               ):
 
         if not os.path.exists(self.lock_file):
@@ -286,7 +287,7 @@ class AutoedDaemon:
             command += full_path
             if not self.is_process_running(command):
                 print('Watching path:', full_path)
-                process = subprocess.Popen(command, shell=True)
+                process = subprocess.Popen(command, shell=True, env={**os.environ, "AUTOED_CONFIG_FILE": config_file} if config_file else None)
                 pid = str(process.pid)
                 self.pids[full_path] = pid
                 self.directories.append(full_path)

--- a/autoed/server/api.py
+++ b/autoed/server/api.py
@@ -57,7 +57,8 @@ class WatcherSetup(BaseModel):
     inotify: bool = False
     sleep_time: float = 30
     log_dir: str = ""
-    slurm: bool = True
+    slurm: bool = False
+    config_file: str = ""
 
 
 @router.post("/watcher")
@@ -68,6 +69,7 @@ async def start_watcher(watcher_setup: WatcherSetup):
         sleep_time=watcher_setup.sleep_time,
         log_dir=watcher_setup.log_dir,
         local=not watcher_setup.slurm,
+        config_file=watcher_setup.config_file or None,
     )
 
 
@@ -85,6 +87,7 @@ class ProcessSetup(BaseModel):
     path: str
     slurm: bool = True
     force: bool = True
+    config_file: str = ""
 
 @router.post("/process")
 async def process(process_setup: ProcessSetup):

--- a/autoed/server/api.py
+++ b/autoed/server/api.py
@@ -91,5 +91,8 @@ class ProcessSetup(BaseModel):
 
 @router.post("/process")
 async def process(process_setup: ProcessSetup):
-    processing_thread = Thread(name=f"proccesor-{process_setup.path}", target=process_dir, kwargs={"dir_name": process_setup.path, "force": process_setup.force})
-    processing_thread.start()
+    command = f"autoed_process {process_setup.path}"
+    if process_setup.force:
+        command += " -f"
+    process = subprocess.Popen(command, shell=True, env={**os.environ, "AUTOED_CONFIG_FILE": process_setup.config_file} if process_setup.config_file else None)
+    return process.pid


### PR DESCRIPTION
This should allow local configuration files to be specified for different calls to the API. 

I think you should just pass on the environment variable and everything else should follow but I may have missed something